### PR TITLE
Paga route and base layout

### DIFF
--- a/src/styles/utils/_mixins.scss
+++ b/src/styles/utils/_mixins.scss
@@ -36,7 +36,6 @@
   line-height: 26px;
 }
 
-
 @mixin H1-mobile {
   font-weight: 800;
   font-size: 32px;

--- a/src/styles/utils/_mixins.scss
+++ b/src/styles/utils/_mixins.scss
@@ -10,6 +10,58 @@
   }
 }
 
+@mixin H1-desktop {
+  font-weight: 800;
+  font-size: 48px;
+  line-height: 56px;
+  letter-spacing: -0.01em;
+}
+
+@mixin H2-desktop {
+  font-weight: 800;
+  font-size: 32px;
+  line-height: 41px;
+  letter-spacing: -0.01em;
+}
+
+@mixin H3-desktop {
+  font-weight: 800;
+  font-size: 22px;
+  line-height: 31px;
+}
+
+@mixin H4-desktop {
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 26px;
+}
+
+
+@mixin H1-mobile {
+  font-weight: 800;
+  font-size: 32px;
+  line-height: 41px;
+  letter-spacing: -0.01em;
+}
+
+@mixin H2-mobile {
+  font-weight: 800;
+  font-size: 22px;
+  line-height: 31px;
+}
+
+@mixin H3-mobile {
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 26px;
+}
+
+@mixin H4-mobile {
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 20px;
+}
+
 @mixin uppercased-text {
   font-family: $global-font;
   font-weight: 800;
@@ -17,4 +69,22 @@
   line-height: 11px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+@mixin buttons-text {
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 21px;
+}
+
+@mixin body-text {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 21px;
+}
+
+@mixin small-text {
+  font-weight: 700;
+  font-size: 12px;
+  line-height: 15px;
 }

--- a/src/styles/utils/_mixins.scss
+++ b/src/styles/utils/_mixins.scss
@@ -10,52 +10,52 @@
   }
 }
 
-@mixin H1-desktop {
+@mixin h1-desktop {
   font-weight: 800;
   font-size: 48px;
   line-height: 56px;
   letter-spacing: -0.01em;
 }
 
-@mixin H2-desktop {
+@mixin h2-desktop {
   font-weight: 800;
   font-size: 32px;
   line-height: 41px;
   letter-spacing: -0.01em;
 }
 
-@mixin H3-desktop {
+@mixin h3-desktop {
   font-weight: 800;
   font-size: 22px;
   line-height: 31px;
 }
 
-@mixin H4-desktop {
+@mixin h4-desktop {
   font-weight: 700;
   font-size: 20px;
   line-height: 26px;
 }
 
-@mixin H1-mobile {
+@mixin h1-mobile {
   font-weight: 800;
   font-size: 32px;
   line-height: 41px;
   letter-spacing: -0.01em;
 }
 
-@mixin H2-mobile {
+@mixin h2-mobile {
   font-weight: 800;
   font-size: 22px;
   line-height: 31px;
 }
 
-@mixin H3-mobile {
+@mixin h3-mobile {
   font-weight: 700;
   font-size: 20px;
   line-height: 26px;
 }
 
-@mixin H4-mobile {
+@mixin h4-mobile {
   font-weight: 700;
   font-size: 16px;
   line-height: 20px;

--- a/src/styles/utils/_vars.scss
+++ b/src/styles/utils/_vars.scss
@@ -1,7 +1,7 @@
 $global-font: 'Mont', sans-serif;
 
 $accent-color: #216cff;
-$secondeary-accent-color: #f447af;
+$secondary-accent-color: #f447af;
 $primary-color: #313237;
 $secondary-color: #89939a;
 $icons-color: #b4bdc3;

--- a/src/styles/utils/_vars.scss
+++ b/src/styles/utils/_vars.scss
@@ -1,6 +1,14 @@
 $global-font: 'Mont', sans-serif;
 
+$accent-color: #216cff;
+$secondeary-accent-color: #f447af;
 $primary-color: #313237;
 $secondary-color: #89939a;
+$icons-color: #b4bdc3;
+$elements-color: #e2e6e9;
+$hover-bg-color: #fafbfc;
+$white-color: #ffffff;
+$green-color: #27ae60;
+$red-color: #eb5757;
 
 $bottom-height: 64px;


### PR DESCRIPTION
We can change mixins with placeholders, like for example:
%h1 {
  font-weight: 600;
  font-size: 60px;
  line-height: 130%;
}
and then create a folder with typography or we can just leave the variant I wrote here.